### PR TITLE
Ensure file gets saved even when show = False

### DIFF
--- a/src/periodic_trends/core.py
+++ b/src/periodic_trends/core.py
@@ -4,7 +4,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from bokeh.io import save as save_
+from bokeh.io import save
 from bokeh.io import show as show_
 from bokeh.models import BasicTicker, ColorBar, ColumnDataSource
 from bokeh.plotting import figure, output_file
@@ -311,6 +311,6 @@ def plotter(
     if show:
         show_(p)
     elif output_filename is not None:
-        save_(p)
+        save(p)
 
     return p


### PR DESCRIPTION
Previously, if `show = False` but `output_filename` is not `None`, the function `plotter(...)` does not generate a file.

I personally found this counterintuitive, so this tiny PR changes the behaviour to ensure the file is written in this instance. 

Of course, if this is not how you would like `plotter(...)` to behave, feel free to close the PR :slightly_smiling_face: 